### PR TITLE
Build and upload docs in CI

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -16,6 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Build documentation
+      shell: bash
       run: python -m sphinx -W --keep-going docs/ docs/_build
     - name: Store built documentation artifact
       uses: actions/upload-artifact@v4

--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,0 +1,28 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+name: Build documentation
+description: Build and upload Sphinx documentation
+runs:
+  using: "composite"
+  steps:
+    - name: Build documentation
+      run: python -m sphinx -W --keep-going docs/ docs/_build
+    - name: Store built documentation artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: qst-docs
+        path: |
+          ./docs/_build/*
+          !**/.doctrees
+          !**/.buildinfo
+        if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,15 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 name: CI Pipeline
 
 on: [pull_request]
@@ -10,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -19,19 +31,9 @@ jobs:
       - name: Run lint
         run: |
           python -m black --check .
-      - name: Build docs
-        run: |
-          python -m sphinx -W --keep-going docs/ docs/_build
-      - name: Store built documentation artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: qst-pr-docs
-          path: |
-            ./docs/_build/*
-            !**/.doctrees
-            !**/.buildinfo
-          if-no-files-found: error
-  
+      - name: Build documentation
+        uses: ./.github/actions/build-docs
+
   run-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
-      
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -20,6 +19,18 @@ jobs:
       - name: Run lint
         run: |
           python -m black --check .
+      - name: Build docs
+        run: |
+          python -m sphinx -W --keep-going docs/ docs/_build
+      - name: Store built documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qst-pr-docs
+          path: |
+            ./docs/_build/*
+            !**/.doctrees
+            !**/.buildinfo
+          if-no-files-found: error
   
   run-tests:
     runs-on: ubuntu-latest
@@ -34,7 +45,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -1,3 +1,15 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 name: Upload documentation
 on:
   tags:
@@ -24,13 +36,4 @@ jobs:
           python -m pip install -r ./requirements-dev.txt
 
       - name: Build documentation
-        run: python -m sphinx -W --keep-going docs/ docs/_build
-      - name: Store built documentation artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: qst-docs
-          path: |
-            ./docs/_build/*
-            !**/.doctrees
-            !**/.buildinfo
-          if-no-files-found: error
+        uses: ./.github/actions/build-docs

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -1,0 +1,36 @@
+name: Upload documentation
+on:
+  tags:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    if: github.repository_owner == 'Qiskit'
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r ./requirements-dev.txt
+
+      - name: Build documentation
+        run: python -m sphinx -W --keep-going docs/ docs/_build
+      - name: Store built documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qst-docs
+          path: |
+            ./docs/_build/*
+            !**/.doctrees
+            !**/.buildinfo
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,20 @@ When adding a new module, you'll also need to add a new file to `docs/apidocs`. 
 
 **Build**
 
-To build the documentation, install Sphinx and the `qiskit-sphinx-theme` (both included in `requirements-dev.txt`) then run the following command.
+To build the documentation, ensure your virtual environment is set up:
 
 ```sh
-make docs
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
 ```
 
-To view the documentation open `docs/_build/html/index.html`. Note that this is just a preview, the final documentation content is pulled into [Qiskit/documentation](https://github.com/qiskit/documentation) and re-rendered into <https://docs.quantum.ibm.com>.
+Then, build the docs with Sphinx:
+
+```sh
+python -m sphinx -W docs/ docs/_build
+```
+
+You can then view the documentation by opening up `docs/_build/index.html`. Note that this is just a preview, the final documentation content is pulled into [Qiskit/documentation](https://github.com/qiskit/documentation) and re-rendered into <https://docs.quantum.ibm.com>.
+
+If you run into Sphinx issues, try running `rm -rf docs/_build` to reset the cache state.


### PR DESCRIPTION
Motivations:

1. Ensure you don't have regressions from PRs
2. Allow you to preview your docs changes in PRs
3. We need this for qiskit/documentation to easily consume the docs from your project

This PR also says how to run the docs locally by setting up a virtual environment. Yaiza and I have been discussing if you may want to migrate to Tox or Poetry. In the meantime, people should be using a virtual environment.