### PR TITLE
Remove deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # qiskit_transpiler_service
 
-> ⚠️ The package **qiskit-transpiler-service** is deprecated. Use **qiskit-ibm-transpiler** instead
-
 A library to use [Qiskit Transpiler service](https://docs.quantum.ibm.com/transpile/qiskit-transpiler-service) and the [AI transpiler passes](https://docs.quantum.ibm.com/transpile/ai-transpiler-passes).
 
 **Note** The Qiskit transpiler service and the AI transpiler passes use different experimental services that are only available for IBM Quantum Premium Plan users. This library and the releated services are an alpha release, subject to change.

--- a/qiskit_transpiler_service/transpiler_service.py
+++ b/qiskit_transpiler_service/transpiler_service.py
@@ -34,7 +34,6 @@ from qiskit import QuantumCircuit
 from .wrappers.transpile import TranspileAPI
 
 logger = logging.getLogger(__name__)
-from warnings import warn
 
 
 class TranspilerService:
@@ -65,11 +64,6 @@ class TranspilerService:
         **kwargs,
     ) -> None:
         """Initializes the instance."""
-
-        warn(
-            "The package qiskit-transpiler-service is deprecated. Use qiskit-ibm-transpiler instead",
-            DeprecationWarning,
-        )
 
         self.transpiler_service = TranspileAPI(**kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
 setup(
     name="qiskit-transpiler-service",
     version="0.4.6",
-    description="Deprecated: use qiskit-ibm-transpiler instead. A library to use Qiskit Transpiler service (https://docs.quantum.ibm.com/transpile/qiskit-transpiler-service) and the AI transpiler passes (https://docs.quantum.ibm.com/transpile/ai-transpiler-passes)",
+    description="A library to use Qiskit Transpiler service (https://docs.quantum.ibm.com/transpile/qiskit-transpiler-service) and the AI transpiler passes (https://docs.quantum.ibm.com/transpile/ai-transpiler-passes)",
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/Qiskit/qiskit-transpiler-service",

--- a/tests/test_transpiler_service.py
+++ b/tests/test_transpiler_service.py
@@ -14,7 +14,6 @@
 
 import numpy as np
 import pytest
-from warnings import catch_warnings
 from qiskit import QuantumCircuit, qasm2, qasm3
 from qiskit.circuit.library import IQP, EfficientSU2, QuantumVolume
 from qiskit.circuit.random import random_circuit
@@ -310,21 +309,6 @@ def test_transpile_failing_task():
     except Exception as e:
         assert "The background task" in str(e)
         assert "FAILED" in str(e)
-
-
-def test_deprecation_warning():
-    with catch_warnings(record=True) as w:
-        TranspilerService(
-            backend_name="ibm_brisbane",
-            ai="true",
-            optimization_level=1,
-        )
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-        assert (
-            str(w[0].message)
-            == "The package qiskit-transpiler-service is deprecated. Use qiskit-ibm-transpiler instead"
-        )
 
 
 def compare_layouts(plugin_circ, non_ai_circ):


### PR DESCRIPTION
### Summary
Before we rename the project to `qiskit-ibm-transpiler`, we need to remove all the deprecation warnings we added to previous project name

Related to #34 