### PR TITLE
Add stacklevel to DeprecationWarning so it appears in Jupyter notebooks

### DIFF
--- a/qiskit_transpiler_service/transpiler_service.py
+++ b/qiskit_transpiler_service/transpiler_service.py
@@ -69,6 +69,7 @@ class TranspilerService:
         warn(
             "The package qiskit-transpiler-service is deprecated. Use qiskit-ibm-transpiler instead",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         self.transpiler_service = TranspileAPI(**kwargs)


### PR DESCRIPTION
### Summary
Hotfix in deprecated `qiskit-transpiler-service` artifact. Added `stacklevel=2` to `DeprecationWarning` so it appears in Jupyter notebooks
