### PR TITLE
Keep trying getting result even in case of HTTPError exception with status 520

### DIFF
--- a/qiskit_ibm_transpiler/wrappers/base.py
+++ b/qiskit_ibm_transpiler/wrappers/base.py
@@ -104,6 +104,10 @@ class QiskitTranspilerService:
         return resp
 
     def request_status(self, endpoint, task_id):
+        def _giveup(e):
+            # Only retry 520 errors
+            return e.response.status_code != 520
+
         @backoff.on_predicate(
             backoff.constant,
             lambda res: res.get("state") not in ["SUCCESS", "FAILURE"],
@@ -119,6 +123,7 @@ class QiskitTranspilerService:
                 requests.exceptions.JSONDecodeError,
                 requests.exceptions.HTTPError,
             ),
+            giveup=_giveup,
             max_time=self.timeout,
         )
         def _request_status(self, endpoint, task_id):

--- a/qiskit_ibm_transpiler/wrappers/base.py
+++ b/qiskit_ibm_transpiler/wrappers/base.py
@@ -117,6 +117,7 @@ class QiskitTranspilerService:
                 requests.exceptions.Timeout,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.JSONDecodeError,
+                requests.exceptions.HTTPError,
             ),
             max_time=self.timeout,
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Fixes #53 

### Summary

when we are trying to get the results from the service, we should keep trying even if we have http errors to avoid failing if we receive an error 520.


### Details and comments
