### PR TITLE
Add release notes for 0.4.9 and 0.5.2

### DIFF
--- a/release-notes/0.4.9.rst
+++ b/release-notes/0.4.9.rst
@@ -1,0 +1,7 @@
+0.4.9 (2024-09-12)
+==================
+
+Bug fixes
+---------
+
+- Fixing the type of ECR gates when loading circuits from the qiskit transpiler service (`64 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/64>`__)

--- a/release-notes/0.5.2.rst
+++ b/release-notes/0.5.2.rst
@@ -1,0 +1,7 @@
+0.5.2 (2024-09-12)
+==================
+
+Bug fixes
+---------
+
+- Fixing the type of ECR gates when loading circuits from the qiskit transpiler service (`63 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/63>`__)


### PR DESCRIPTION
0.4 and 0.5 aren't yet using our new release process, so these had to be added manually.