### PR TITLE
Add iterative decomposition to QASM3 circuits

### DIFF
--- a/qiskit_ibm_transpiler/wrappers/__init__.py
+++ b/qiskit_ibm_transpiler/wrappers/__init__.py
@@ -34,4 +34,4 @@ Classes
 from .ai_routing import AIRoutingAPI
 from .ai_synthesis import AICliffordAPI, AILinearFunctionAPI, AIPermutationAPI
 from .base import BackendTaskError, QiskitTranspilerService
-from .transpile import TranspileAPI, _get_circuit_from_result, _get_circuit_from_qasm
+from .transpile import TranspileAPI, _get_circuit_from_result

--- a/qiskit_ibm_transpiler/wrappers/ai_routing.py
+++ b/qiskit_ibm_transpiler/wrappers/ai_routing.py
@@ -10,12 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import os
-from urllib.parse import urljoin
-
-from qiskit import QuantumCircuit, qasm2, qasm3
-from qiskit.qasm2 import QASM2ExportError
-
+from qiskit import QuantumCircuit
+from qiskit_ibm_transpiler.utils import get_circuit_from_qasm, input_to_qasm
 from .base import QiskitTranspilerService
 from typing import List, Union, Literal
 
@@ -41,12 +37,7 @@ class AIRoutingAPI(QiskitTranspilerService):
             OptimizationOptions, List[OptimizationOptions], None
         ] = None,
     ):
-        is_qasm3 = False
-        try:
-            qasm = qasm2.dumps(circuit)
-        except QASM2ExportError:
-            qasm = qasm3.dumps(circuit)
-            is_qasm3 = True
+        qasm = input_to_qasm(circuit)
 
         body_params = {
             "qasm": qasm.replace("\n", " "),
@@ -65,11 +56,7 @@ class AIRoutingAPI(QiskitTranspilerService):
         )
 
         if routing_resp.get("success"):
-            routed_circuit = (
-                qasm3.loads(routing_resp["qasm"])
-                if is_qasm3
-                else QuantumCircuit.from_qasm_str(routing_resp["qasm"])
-            )
+            routed_circuit = get_circuit_from_qasm(routing_resp["qasm"])
             return (
                 routed_circuit,
                 routing_resp["layout"]["initial"],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #46 

### Details and comments

Added iterative QASM3 decomposition in case the exported qasm3 cannot be converted back to a QuantumCircuit.
I have also unified the Qasm import/export functions used by transpile and routing.
