### PR TITLE
Add release notes for 0.5-0.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,5 +167,4 @@ the patch release like `0.21.1`. Then, from the `stable/*` branch, create a new
 Git tag for the full version number, like `git tag 0.21.1`, and
 push the tag to GitHub.
 
-After the release, you need to cherry-pick the release notes prep from `stable/*` to
-the `main` branch, such as from `stable/0.21` to `main`.
+After the release, you need to cherry-pick the release notes prep from `stable/*` to the `main` branch _and_ the stable branch for the latest minor version. For example, if the latest minor version is `0.3` and you released the patch `0.2.3`, then you need the copy the release notes `0.2.3.rst` into both `main` and `stable/0.3`. This ensures that the release notes show up for all future versions.

--- a/release-notes/0.5.4.rst
+++ b/release-notes/0.5.4.rst
@@ -1,0 +1,7 @@
+0.5.4 (2024-10-30)
+==================
+
+New features
+------------
+
+- In case of failure, always retry the GET request to retrieve a result unitl the timeout is reached. Increase the delay between requests to 5 seconds when we are over 1 minute. Retry transpilation POST request three times in case of failure. (`97 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/97>`__)

--- a/release-notes/0.5.5.rst
+++ b/release-notes/0.5.5.rst
@@ -1,0 +1,7 @@
+0.5.5 (2024-10-31)
+==================
+
+Bug fixes
+---------
+
+- Added fix to avoid random test errors. Check that result exists when result is success. (`105 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/105>`__)

--- a/release-notes/0.5.6.rst
+++ b/release-notes/0.5.6.rst
@@ -1,0 +1,7 @@
+0.5.6 (2024-11-07)
+==================
+
+New features
+------------
+
+- Retry http requests after any RequestException (`111 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/111>`__)

--- a/release-notes/0.5.7.rst
+++ b/release-notes/0.5.7.rst
@@ -1,0 +1,7 @@
+0.5.7 (2024-11-11)
+==================
+
+New features
+------------
+
+- Use QPY as exchange format with service (`104 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/104>`__)

--- a/release-notes/0.6.2.rst
+++ b/release-notes/0.6.2.rst
@@ -1,0 +1,7 @@
+0.6.2 (2024-10-30)
+==================
+
+New features
+------------
+
+- In case of failure, always retry the GET request to retrieve a result unitl the timeout is reached. Increase the delay between requests to 5 seconds when we are over 1 minute. Retry transpilation POST request three times in case of failure. (`97 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/97>`__)

--- a/release-notes/0.6.3.rst
+++ b/release-notes/0.6.3.rst
@@ -1,0 +1,7 @@
+0.6.3 (2024-10-31)
+==================
+
+Bug fixes
+---------
+
+- Added fix to avoid random test errors. Check that result exists when result is success. (`105 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/105>`__)

--- a/release-notes/0.6.4.rst
+++ b/release-notes/0.6.4.rst
@@ -1,0 +1,7 @@
+0.6.4 (2024-11-07)
+==================
+
+New features
+------------
+
+- Retry http requests after any RequestException (`111 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/111>`__)

--- a/release-notes/0.6.5.rst
+++ b/release-notes/0.6.5.rst
@@ -1,0 +1,7 @@
+0.6.5 (2024-11-11)
+==================
+
+New features
+------------
+
+- Use QPY as exchange format with service (`104 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/104>`__)

--- a/release-notes/0.7.1.rst
+++ b/release-notes/0.7.1.rst
@@ -1,0 +1,7 @@
+0.7.1 (2024-10-30)
+==================
+
+New features
+------------
+
+- In case of failure, always retry the GET request to retrieve a result unitl the timeout is reached. Increase the delay between requests to 5 seconds when we are over 1 minute. Retry transpilation POST request three times in case of failure. (`97 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/97>`__)

--- a/release-notes/0.7.2.rst
+++ b/release-notes/0.7.2.rst
@@ -1,0 +1,7 @@
+0.7.2 (2024-10-31)
+==================
+
+Bug fixes
+---------
+
+- Added fix to avoid random test errors. Check that result exists when result is success. (`105 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/105>`__)

--- a/release-notes/0.7.3.rst
+++ b/release-notes/0.7.3.rst
@@ -1,0 +1,7 @@
+0.7.3 (2024-11-06)
+==================
+
+New features
+------------
+
+- Retry http requests after any RequestException (`111 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/111>`__)

--- a/release-notes/0.7.4.rst
+++ b/release-notes/0.7.4.rst
@@ -1,0 +1,7 @@
+0.7.4 (2024-11-11)
+==================
+
+New features
+------------
+
+- Use QPY as exchange format with service (`104 <https://github.com/Qiskit/qiskit-ibm-transpiler/pull/104>`__)


### PR DESCRIPTION
These needed to be added to both `main` and `stable/0.8` for them to show up in docs.quantum.ibm.com.

This PR also updates the contributor guide to hopefully explain that better.