### PR TITLE
feat: implement package versioning

### DIFF
--- a/qiskit_ibm_transpiler/__init__.py
+++ b/qiskit_ibm_transpiler/__init__.py
@@ -16,6 +16,7 @@ from .ai import AIRouting
 from .ai_passmanager import generate_ai_pass_manager
 from .transpiler_service import TranspilerService
 from .utils import create_random_linear_function, get_metrics
+from .version import __version__
 
 logging.basicConfig()
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/qiskit_ibm_transpiler/version.py
+++ b/qiskit_ibm_transpiler/version.py
@@ -1,0 +1,108 @@
+import os
+import subprocess
+from importlib.metadata import PackageNotFoundError, version
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _run_command(cmd):
+    """
+    Run a shell command with a minimal environment and return its output.
+    Args:
+        cmd (list): Command to execute as a list of strings.
+    Returns:
+        str: The command's output.
+    Raises:
+        OSError: If the command execution fails.
+    """
+
+    env = {
+        key: os.environ.get(key)
+        for key in ["SYSTEMROOT", "PATH"]
+        if os.environ.get(key)
+    }
+    env.update({"LANGUAGE": "C", "LANG": "C", "LC_ALL": "C"})
+
+    try:
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=os.path.dirname(ROOT_DIR),
+        ) as proc:
+            stdout, stderr = proc.communicate()
+            if proc.returncode > 0:
+                raise OSError(
+                    f"Command {cmd} failed with code {proc.returncode}: {stderr.strip().decode('ascii')}"
+                )
+        return stdout.strip().decode("ascii")
+
+    except Exception as e:
+        raise OSError(f"Error running command {cmd}: {str(e)}")
+
+
+def _get_version_from_metadata():
+    """
+    Retrieve the package version from importlib.metadata.
+    Returns:
+        str: The installed package version, or None if not found.
+    """
+    try:
+        return version("qiskit-ibm-transpiler")
+    except PackageNotFoundError:
+        return "Unknown"
+
+
+def _get_git_commit_hash() -> str | None:
+    """
+    Get the latest Git commit hash.
+    Returns:
+        str | None: The first 7 characters of the Git commit hash, or None if unavailable.
+    """
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+            )
+            .strip()
+            .decode("ascii")[:7]
+        )
+    except subprocess.SubprocessError:
+        return None
+
+
+def _is_release_tag_present() -> bool:
+    """
+    Check if the current HEAD is pointing to a release tag.
+    Returns:
+        bool: True if a release tag is found, otherwise False.
+    """
+    try:
+        release_tags = _run_command(["git", "tag", "-l", "--points-at", "HEAD"])
+        return bool(release_tags)
+    except OSError:
+        return False
+
+
+def get_version_info() -> str:
+    """
+    Retrieve the full version string:
+    - If the package is installed, use importlib.metadata.version() (PEP standard)
+      (https://docs.python.org/3/library/importlib.metadata.html)
+    - If the repository is a Git repo but does not have a release tag, append the commit hash.
+    Returns:
+        str: The version string.
+    """
+    version_info = _get_version_from_metadata()
+    is_a_git_repo = os.path.exists(os.path.join(ROOT_DIR, ".git"))
+
+    if is_a_git_repo and not _is_release_tag_present():
+
+        if git_hash := _get_git_commit_hash():
+            version_info += f".dev0+{git_hash}"
+
+    return version_info
+
+
+__version__ = get_version_info()

--- a/qiskit_ibm_transpiler/version.py
+++ b/qiskit_ibm_transpiler/version.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from importlib.metadata import PackageNotFoundError, version
+from typing import Union
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -54,7 +55,7 @@ def _get_version_from_metadata():
         return "Unknown"
 
 
-def _get_git_commit_hash() -> str | None:
+def _get_git_commit_hash() -> Union[str, None]:
     """
     Get the latest Git commit hash.
     Returns:

--- a/release-notes/unreleased/18.feat.rst
+++ b/release-notes/unreleased/18.feat.rst
@@ -1,0 +1,22 @@
+Added a `__version__` attribute to `qiskit_ibm_transpiler` to enable version retrieval.
+
+**What changed?**
+- Introduced `qiskit_ibm_transpiler/version.py` for dynamically retrieving the package version.
+- Exposed `__version__` in `__init__.py`, allowing users to access the installed package version.
+- If the package is installed normally, it will return the version as defined in `importlib.metadata.version()`.
+- If the package is being used from a Git repository **without a release tag**, it appends the commit hash.
+
+**How to use the new feature?**
+Users can now check the installed version by running:
+
+.. code:: python
+
+    import qiskit_ibm_transpiler
+    print(qiskit_ibm_transpiler.__version__)
+
+**Example outputs:**
+- Installed via `pip install qiskit-ibm-transpiler`: ``0.10.1``
+- Running from Git with a release tag: ``0.10.1``
+- Running from Git **without a release tag**: ``0.10.1.dev0+a1b2c3d``
+
+Fixes `#18 <https://github.com/Qiskit/qiskit-ibm-transpiler/issues/18>`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Also, please add a release note file using Reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [] I have added the tests to cover my changes. I have not added specific tests for this change because it relies on `importlib.metadata.version()`, which is a built-in Python function that retrieves package metadata. Since the behavior is inherently tied to the installed package version, additional tests are not necessary.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### **Summary**
This PR adds version retrieval to `qiskit_ibm_transpiler` by:
- Creating a `version.py` module to obtain the package version using `importlib.metadata.version()`.
- Exposing `__version__` in `__init__.py` to provide a standardized way to access the version.
- Ensuring compatibility with Git repositories by appending the commit hash if no release tag is present.
- Following PEP 8 and Qiskit’s contribution guidelines.

### **Details and Comments**
- The versioning logic follows the same approach as used in [Qiskit](https://github.com/Qiskit/qiskit/blob/9d8be7e7553a9336a55ba6f5c755e4accdb2695d/qiskit/version.py#L64-L84).
- If the package is installed, it retrieves the version from `importlib.metadata.version()`.
- If running from a Git repository **without a release tag**, the commit hash is appended (e.g., `0.10.1.dev0+a1b2c3d`).
- The implementation has been formatted using `black` and checked with `ruff` to ensure compliance with the project's CI/CD.

### **Related Issue**
Fixes #18
