### PR TITLE
Refactor: centralize optimization options

### DIFF
--- a/qiskit_ibm_transpiler/ai/routing.py
+++ b/qiskit_ibm_transpiler/ai/routing.py
@@ -28,14 +28,12 @@ from qiskit.transpiler import CouplingMap, TranspilerError
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.layout import Layout
 
+from qiskit_ibm_transpiler.types import OptimizationOptions
 from qiskit_ibm_transpiler.utils import get_qiskit_runtime_service
 from qiskit_ibm_transpiler.wrappers import AILocalRouting, AIRoutingAPI
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-# TODO: Reuse this code, it's repeated several times
-OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]
 
 
 def build_final_optimization_preferences(

--- a/qiskit_ibm_transpiler/transpiler_service.py
+++ b/qiskit_ibm_transpiler/transpiler_service.py
@@ -31,12 +31,10 @@ from typing import Dict, List, Literal, Union
 
 from qiskit import QuantumCircuit
 
+from .types import OptimizationOptions
 from .wrappers.transpile import TranspileAPI
 
 logger = logging.getLogger(__name__)
-
-# TODO: Reuse this code, it's repeated several times
-OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]
 
 
 class TranspilerService:

--- a/qiskit_ibm_transpiler/types.py
+++ b/qiskit_ibm_transpiler/types.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2025 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+===============================================================================
+Qiskit IBM Transpiler - Type Definitions (:mod:`qiskit_ibm_transpiler.types`)
+===============================================================================
+
+This module defines shared type aliases used throughout the `qiskit_ibm_transpiler`
+package, centralizing type definitions.
+
+.. currentmodule:: qiskit_ibm_transpiler.types
+
+Type Aliases
+============
+This module provides common type definitions used across multiple transpiler components.
+
+- **OptimizationOptions**: Specifies different optimization strategies for quantum circuits.
+
+Classes
+=======
+.. autosummary::
+   :toctree: ../stubs/
+
+   TranspilerService
+"""
+
+from typing import Literal
+
+OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]

--- a/qiskit_ibm_transpiler/wrappers/ai_api_routing.py
+++ b/qiskit_ibm_transpiler/wrappers/ai_api_routing.py
@@ -15,6 +15,7 @@ from typing import List, Literal, Union
 from qiskit import QuantumCircuit
 from qiskit.transpiler import CouplingMap
 
+from qiskit_ibm_transpiler.types import OptimizationOptions
 from qiskit_ibm_transpiler.utils import (
     deserialize_circuit_from_qpy_or_qasm,
     get_circuit_from_qpy,
@@ -23,9 +24,6 @@ from qiskit_ibm_transpiler.utils import (
 )
 
 from .base import QiskitTranspilerService
-
-# TODO: Reuse this code, it's repeated several times
-OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]
 
 
 class AIRoutingAPI(QiskitTranspilerService):

--- a/qiskit_ibm_transpiler/wrappers/ai_local_routing.py
+++ b/qiskit_ibm_transpiler/wrappers/ai_local_routing.py
@@ -16,6 +16,7 @@ from typing import List, Literal, Union
 from qiskit import QuantumCircuit
 from qiskit.transpiler import CouplingMap
 
+from qiskit_ibm_transpiler.types import OptimizationOptions
 from qiskit_ibm_transpiler.utils import get_circuit_from_qasm, input_to_qasm
 
 ai_local_package = "qiskit_ibm_ai_local_transpiler"
@@ -28,9 +29,6 @@ AIRoutingInference = getattr(
     qiskit_ibm_ai_local_transpiler, "AIRoutingInference", "AIRoutingInference not found"
 )
 
-
-# TODO: Reuse this code, it's repeated several times
-OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]
 
 OP_LEVELS = {
     1: {"full_its": 8, "its": 2, "reps": 2, "runs": 1, "max_time": 30},

--- a/qiskit_ibm_transpiler/wrappers/transpile.py
+++ b/qiskit_ibm_transpiler/wrappers/transpile.py
@@ -19,6 +19,7 @@ from qiskit.circuit import QuantumCircuit, QuantumRegister, Qubit
 from qiskit.transpiler import TranspileLayout
 from qiskit.transpiler.layout import Layout
 
+from qiskit_ibm_transpiler.types import OptimizationOptions
 from qiskit_ibm_transpiler.utils import (
     deserialize_circuit_from_qpy_or_qasm,
     get_circuit_from_qpy,
@@ -31,9 +32,6 @@ from qiskit_ibm_transpiler.wrappers import QiskitTranspilerService
 # setting backoff logger to error level to avoid too much logging
 logging.getLogger("backoff").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
-
-# TODO: Reuse this code, it's repeated several times
-OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]
 
 
 class TranspileAPI(QiskitTranspilerService):

--- a/release-notes/unreleased/166.refactor.rst
+++ b/release-notes/unreleased/166.refactor.rst
@@ -1,0 +1,20 @@
+Refactored type definitions by centralizing `OptimizationOptions` in `qiskit_ibm_transpiler/types.py`.
+
+**What changed?**
+- Introduced `qiskit_ibm_transpiler/types.py` to store shared type definitions.
+- Moved the `OptimizationOptions` type alias to `types.py`, eliminating redundancy.
+- Updated all relevant imports to use the centralized definition.
+- Ensured compliance with **PEP 484** recommendations for type aliasing.
+
+**How does this affect users?**
+- No breaking changes; this is an internal refactor.
+- Any direct references to `OptimizationOptions` in multiple files now import it from `types.py`.
+
+**Updated import path:**
+.. code:: python
+
+    from qiskit_ibm_transpiler.types import OptimizationOptions
+
+This improves code maintainability and makes future type updates easier.
+
+Fixes `#166 <https://github.com/Qiskit/qiskit-ibm-transpiler/issues/166>`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### **Summary**  
This PR refactors the code by introducing a centralized `types.py` module within `qiskit_ibm_transpiler` to store shared type definitions. Specifically, it moves the `OptimizationOptions` type alias to `types.py`, reducing redundancy and improving maintainability. This aligns with **PEP 484** recommendations for better code organization (see https://github.com/Qiskit/qiskit-ibm-transpiler/issues/166).

### **Details and comments**  
#### **Changes in this PR**  
- Created a new `qiskit_ibm_transpiler/types.py` module to house common type definitions.  
- Moved the `OptimizationOptions` type alias from multiple locations into `types.py`:  

  ```python
  from typing import Literal
  
  OptimizationOptions = Literal["n_cnots", "n_gates", "cnot_layers", "layers", "noise"]
  ```
  
- Updated all relevant imports to reference `OptimizationOptions` from `types.py`.  
- Ensured compliance with **Black** (formatting) and **Ruff** (linting).  

---

#### **Technical Considerations**  
- **No `TypeAlias` Usage**:  
  `typing.TypeAlias` requires **Python 3.10+**, but since the minimum supported version is **Python 3.9**, a simple `Literal[...]` assignment was used instead.  

- **Testing Notes**:  
  Due to local environment limitations (e.g., missing secrets and permissions when running act and Docker-based tests for all CI/CD workflows from GitHub Actions, as @jesus-talavera-ibm mentioned in my previous PR), I was unable to execute the full test suite. However, I verified that the project runs correctly on **Python 3.9**. CI should catch any issues, and I will address them as needed.  

- If any test failures arise due to my local limitations, I’ll make the necessary adjustments based on CI feedback.  
- Open to suggestions on further centralizing other type definitions.  

Thanks for reviewing! 

Related Issue
Fixes https://github.com/Qiskit/qiskit-ibm-transpiler/issues/166
