### PR TITLE
Update intersphinx mapping URLs & others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-> ⚠️ This file is not maintained anymore. Please go to: https://docs.quantum.ibm.com/api/qiskit-ibm-transpiler/release-notes
+> ⚠️ This file is not maintained anymore. Please go to: https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-transpiler/release-notes
 
 All notable changes to this project will be documented in this file.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 # Code of Conduct
 
-All members of this project agree to adhere to the IBM Quantum Code of Conduct listed [here](https://docs.quantum.ibm.com/open-source/code-of-conduct)
+All members of this project agree to adhere to the IBM Quantum Code of Conduct listed [here](https://quantum.cloud.ibm.com/docs/open-source/code-of-conduct)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Then, build the docs:
 scripts/docs
 ```
 
-You can then view the documentation by opening up `docs/_build/index.html`. Note that this is just a preview, the final documentation content is pulled into [Qiskit/documentation](https://github.com/qiskit/documentation) and re-rendered into <https://docs.quantum.ibm.com>.
+You can then view the documentation by opening up `docs/_build/index.html`. Note that this is just a preview, the final documentation content is pulled into [Qiskit/documentation](https://github.com/qiskit/documentation) and re-rendered into <https://quantum.cloud.ibm.com/docs>.
 
 If you run into Sphinx issues, try running `scripts/docs-clean` to reset the cache state.
 
@@ -194,4 +194,4 @@ After the release, you need to cherry-pick the release notes prep from `stable/*
 * After that tag is pushed, GitHub actions will automatically release that new version to [pypi](https://pypi.org/project/qiskit-ibm-transpiler/)
 * Only for minor releases, create the ``stable/x.x`` branch from tagged commit in ``main``
 * Go to https://github.com/Qiskit/qiskit-ibm-transpiler/tags and click on the three dots next to the tag you just created and select "Create release"
-* Name: "x.x.x" and Description: "Refer to https://docs.quantum.ibm.com/api/qiskit-ibm-transpiler/release-notes for release notes". Click on "Set as the latest release" only if that's the case, for patches in previous release keep that field unselected
+* Name: "x.x.x" and Description: "Refer to https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-transpiler/release-notes for release notes". Click on "Set as the latest release" only if that's the case, for patches in previous release keep that field unselected

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qiskit_ibm_transpiler
 
-A library to use [Qiskit Transpiler Service](https://docs.quantum.ibm.com/guides/qiskit-transpiler-service) and the [AI transpiler passes](https://docs.quantum.ibm.com/transpile/ai-transpiler-passes).
+A library to use [Qiskit Transpiler Service](https://quantum.cloud.ibm.com/docs/guides/qiskit-transpiler-service) and the [AI transpiler passes](https://quantum.cloud.ibm.com/docs/guides/ai-transpiler-passes).
 
 **Note** The Qiskit Transpiler Service and the AI transpiler passes use different experimental services that are only available for IBM Quantum Premium Plan users. This library and the releated services are an alpha release, subject to change.
 
@@ -120,9 +120,9 @@ The synthesis respects the coupling map of the device: it can be run safely afte
 
 The following synthesis passes are available from `qiskit_ibm_transpiler.ai.synthesis`:
 
-- _AICliffordSynthesis_: Synthesis for [Clifford](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.Clifford) circuits (blocks of `H`, `S` and `CX` gates). Currently up to 9 qubit blocks.
-- _AILinearFunctionSynthesis_: Synthesis for [Linear Function](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.LinearFunction) circuits (blocks of `CX` and `SWAP` gates). Currently up to 9 qubit blocks.
-- _AIPermutationSynthesis_: Synthesis for [Permutation](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.Permutation#permutation) circuits (blocks of `SWAP` gates). Currently available for 65, 33, and 27 qubit blocks.
+- _AICliffordSynthesis_: Synthesis for [Clifford](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.quantum_info.Clifford) circuits (blocks of `H`, `S` and `CX` gates). Currently up to 9 qubit blocks.
+- _AILinearFunctionSynthesis_: Synthesis for [Linear Function](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.circuit.library.LinearFunction) circuits (blocks of `CX` and `SWAP` gates). Currently up to 9 qubit blocks.
+- _AIPermutationSynthesis_: Synthesis for [Permutation](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.circuit.library.Permutation#permutation) circuits (blocks of `SWAP` gates). Currently available for 65, 33, and 27 qubit blocks.
 - _AIPauliNetworkSynthesis_: Synthesis for [Pauli Network](/api/qiskit/qiskit.circuit.library.PauliNetwork) circuits (blocks of `H`, `S`, `SX`, `CX`, `RX`, `RY` and `RZ` gates). Currently up to six qubit blocks.
 
 We expect to gradually increase the size of the supported blocks.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,9 +47,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
     "rustworkx": ("https://www.rustworkx.org/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "qiskit-ibm-runtime": (
-        "https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/",
+        "https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/",
         None,
     ),
     "qiskit-aer": ("https://qiskit.github.io/qiskit-aer/", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Qiskit IBM Transpiler |release| API Docs Preview
 ####################################################
 
-Qiskit IBM Transpiler docs live at docs.quantum.ibm.com and come from https://github.com/Qiskit/documentation.
+Qiskit IBM Transpiler docs live at https://quantum.cloud.ibm.com/docs and come from https://github.com/Qiskit/documentation.
 This site is only used to generate our API docs, which then get migrated to
 https://github.com/Qiskit/documentation.
 

--- a/qiskit_ibm_transpiler/wrappers/base.py
+++ b/qiskit_ibm_transpiler/wrappers/base.py
@@ -42,7 +42,7 @@ def _get_token_from_system():
         if not qiskit_file.exists():
             raise Exception(
                 f"Credentials file {qiskit_file} does not exist. Please set env var QISKIT_IBM_TOKEN to access the service, or save your IBM Quantum API token using QiskitRuntimeService. "
-                "More info about saving your token using QiskitRuntimeService https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#save_account"
+                "More info about saving your token using QiskitRuntimeService https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#save_account"
             )
         with open(qiskit_file, "r") as _sc:
             creds = json.loads(_sc.read())
@@ -50,7 +50,7 @@ def _get_token_from_system():
         if token is None:
             raise Exception(
                 f"default-ibm-quantum not found in {qiskit_file}. Please set env var QISKIT_IBM_TOKEN to access the service, or save your IBM Quantum API token using QiskitRuntimeService. "
-                "More info about saving your token using QiskitRuntimeService https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#save_account"
+                "More info about saving your token using QiskitRuntimeService https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#save_account"
             )
     return token
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements = [
 setup(
     name="qiskit-ibm-transpiler",
     version="0.11.1",
-    description="A library to use Qiskit IBM Transpiler (https://docs.quantum.ibm.com/transpile/qiskit-ibm-transpiler) and the AI transpiler passes (https://docs.quantum.ibm.com/transpile/ai-transpiler-passes)",
+    description="A library to use Qiskit IBM Transpiler (https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-transpiler) and the AI transpiler passes (https://quantum.cloud.ibm.com/docs/guides/ai-transpiler-passes)",
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/Qiskit/qiskit-ibm-transpiler",


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.