### PR TITLE
Improve Collection Pass Performance via Precomputed Siblings and Queue Optimization #UnitaryHack2025

### DIFF
--- a/ai-large-circuit-speed-test.ipynb
+++ b/ai-large-circuit-speed-test.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit\n",
+    "from qiskit.circuit.library import Permutation, EfficientSU2\n",
+    "from qiskit.quantum_info import random_clifford\n",
+    "from qiskit.transpiler import PassManager, generate_preset_pass_manager\n",
+    "\n",
+    "from qiskit_ibm_transpiler.ai.collection import CollectLinearFunctions, CollectCliffords, CollectPauliNetworks, CollectPermutations\n",
+    "from qiskit_ibm_transpiler.ai.synthesis import AILinearFunctionSynthesis, AIPauliNetworkSynthesis, AICliffordSynthesis, AIPermutationSynthesis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fake_marrakesh 156\n"
+     ]
+    }
+   ],
+   "source": [
+    "from qiskit_ibm_runtime.fake_provider.backends.marrakesh import FakeMarrakesh\n",
+    "\n",
+    "backend = FakeMarrakesh()\n",
+    "coupling_map = backend.coupling_map\n",
+    "n_qubits = backend.num_qubits\n",
+    "\n",
+    "print(backend.name, backend.num_qubits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linear Functions Circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iterations = 32\n",
+    "commutative = True\n",
+    "backwards = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original Linear Fnc circuit -> Depth: 509, Gates(2q): 1183\n"
+     ]
+    }
+   ],
+   "source": [
+    "circuit = QuantumCircuit(n_qubits)\n",
+    "\n",
+    "for c in range(iterations):\n",
+    "    nq = 8\n",
+    "    qs = np.random.choice(range(circuit.num_qubits), size=nq, replace=False)\n",
+    "    circuit.compose(random_clifford(nq).to_circuit(), qubits=qs.tolist(), inplace=True)\n",
+    "    for q in qs:\n",
+    "        circuit.t(q)\n",
+    "\n",
+    "print(\n",
+    "    f\"Original Linear Fnc circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "#circuit.draw(fold=-1, scale=0.3, style=\"iqp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qiskit_lvl3_transpiler = generate_preset_pass_manager(\n",
+    "    optimization_level=3, coupling_map=coupling_map\n",
+    ")\n",
+    "lvl3_transpiled_circuit = qiskit_lvl3_transpiler.run(circuit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "start_time = time.time()\n",
+    "ai_linear_functions_synthesis_pass = PassManager(\n",
+    "    [\n",
+    "        CollectLinearFunctions(\n",
+    "            do_commutative_analysis=commutative,\n",
+    "            collect_from_back=backwards,\n",
+    "        ),\n",
+    "        AILinearFunctionSynthesis(coupling_map=coupling_map),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "synthesized_circuit_local = ai_linear_functions_synthesis_pass.run(\n",
+    "    lvl3_transpiled_circuit\n",
+    ")\n",
+    "end_time = time.time()\n",
+    "delta = end_time - start_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time taken for local AI synthesis: 4.06 seconds\n",
+      "Original Linear Fnc circuit -> Depth: 509, Gates(2q): 1183\n",
+      "Synthesized Linear Fnc circuit (local AI) -> Depth: 2186, Gates(2q): 6689\n",
+      ">>>>Gate Speed: 291.48 gates/second\n",
+      ">>>>Complexity Speed: 148361.62 complexity/second\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Time taken for local AI synthesis: {delta:.2f} seconds\")\n",
+    "print(\n",
+    "    f\"Original Linear Fnc circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Synthesized Linear Fnc circuit (local AI) -> Depth: {synthesized_circuit_local.decompose(reps=3).depth()}, Gates(2q): {synthesized_circuit_local.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "complexity = circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    "speed = circuit.decompose(reps=3).num_nonlocal_gates() / delta\n",
+    "speed2 = complexity / delta\n",
+    "print(f\">>>>Gate Speed: {speed:.2f} gates/second\")\n",
+    "print(f\">>>>Complexity Speed: {speed2:.2f} complexity/second\")\n",
+    "#synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Permutation Circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original Permutations circuit -> Depth: 465, Gates(2q): 465\n"
+     ]
+    }
+   ],
+   "source": [
+    "circuit = QuantumCircuit(n_qubits)\n",
+    "circuit.append(\n",
+    "    Permutation(\n",
+    "        num_qubits=n_qubits, pattern=[(i + 1) % n_qubits for i in range(n_qubits)]\n",
+    "    ),\n",
+    "    qargs=range(n_qubits),\n",
+    ")\n",
+    "circuit = circuit.decompose(reps=2)\n",
+    "\n",
+    "print(\n",
+    "    f\"Original Permutations circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "\n",
+    "#circuit.draw(fold=-1, scale=0.3, style=\"iqp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qiskit_lvl3_transpiler = generate_preset_pass_manager(\n",
+    "optimization_level=3, coupling_map=coupling_map\n",
+    ")\n",
+    "lvl3_transpiled_circuit = qiskit_lvl3_transpiler.run(circuit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "start_time = time.time()\n",
+    "ai_linear_functions_synthesis_pass = PassManager(\n",
+    "    [\n",
+    "        CollectPermutations(\n",
+    "            do_commutative_analysis=commutative,\n",
+    "            collect_from_back=backwards,\n",
+    "            max_block_size=n_qubits,\n",
+    "        ), ## or max_block_size=27\n",
+    "        AIPermutationSynthesis(coupling_map=coupling_map),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "synthesized_circuit_local = ai_linear_functions_synthesis_pass.run(\n",
+    "    lvl3_transpiled_circuit\n",
+    ")\n",
+    "end_time = time.time()\n",
+    "delta = end_time - start_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time taken for Permutations with Local AI: 0.00 seconds\n",
+      "Original Permutations circuit -> Depth: 465, Gates(2q): 465\n",
+      "Synthesized Permutations circuit (local AI) -> Depth: 0, Gates(2q): 0\n",
+      ">>>>Gate Speed: 154434.35 gates/second\n",
+      ">>>>Complexity Speed: 71811971.05 complexity/second\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Time taken for Permutations with Local AI: {delta:.2f} seconds\")\n",
+    "print(\n",
+    "    f\"Original Permutations circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Synthesized Permutations circuit (local AI) -> Depth: {synthesized_circuit_local.decompose(reps=3).depth()}, Gates(2q): {synthesized_circuit_local.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "complexity = circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    "speed = circuit.decompose(reps=3).num_nonlocal_gates() / delta\n",
+    "speed2 = complexity / delta\n",
+    "print(f\">>>>Gate Speed: {speed:.2f} gates/second\")\n",
+    "print(f\">>>>Complexity Speed: {speed2:.2f} complexity/second\")\n",
+    "#synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Eficient SU2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original EfficientSU2 circuit -> Depth: 160, Gates(2q): 156\n"
+     ]
+    }
+   ],
+   "source": [
+    "circuit = EfficientSU2(n_qubits, entanglement=\"circular\", reps=1).decompose()\n",
+    "print(\n",
+    "    f\"Original EfficientSU2 circuit -> Depth: {circuit.depth()}, Gates(2q): {circuit.num_nonlocal_gates()}\"\n",
+    ")\n",
+    "#circuit.draw(fold=-1, scale=0.2, style=\"iqp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qiskit_lvl3_transpiler = generate_preset_pass_manager(\n",
+    "optimization_level=3, coupling_map=coupling_map\n",
+    ")\n",
+    "lvl3_transpiled_circuit = qiskit_lvl3_transpiler.run(circuit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "start_time = time.time()\n",
+    "ai_linear_functions_synthesis_pass = PassManager(\n",
+    "    [\n",
+    "        CollectLinearFunctions(\n",
+    "            do_commutative_analysis=commutative,\n",
+    "            collect_from_back=backwards,\n",
+    "        ),\n",
+    "        AILinearFunctionSynthesis(coupling_map=coupling_map),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "synthesized_circuit_local = ai_linear_functions_synthesis_pass.run(\n",
+    "    lvl3_transpiled_circuit\n",
+    ")\n",
+    "end_time = time.time()\n",
+    "delta = end_time - start_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time taken for EfficientSU2 with Local AI: 0.48 seconds\n",
+      "Original EfficientSU2 circuit -> Depth: 160, Gates(2q): 156\n",
+      "Synthesized EfficientSU2 circuit (local AI) -> Depth: 588, Gates(2q): 591\n",
+      ">>>>Gate Speed: 327.02 gates/second\n",
+      ">>>>Complexity Speed: 52322.83 complexity/second\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Time taken for EfficientSU2 with Local AI: {delta:.2f} seconds\")\n",
+    "print(\n",
+    "    f\"Original EfficientSU2 circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Synthesized EfficientSU2 circuit (local AI) -> Depth: {synthesized_circuit_local.decompose(reps=3).depth()}, Gates(2q): {synthesized_circuit_local.decompose(reps=3).num_nonlocal_gates()}\"\n",
+    ")\n",
+    "complexity = circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    "speed = circuit.decompose(reps=3).num_nonlocal_gates() / delta\n",
+    "speed2 = complexity / delta\n",
+    "print(f\">>>>Gate Speed: {speed:.2f} gates/second\")\n",
+    "print(f\">>>>Complexity Speed: {speed2:.2f} complexity/second\")\n",
+    "#synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ai-large-circuit-speed-test.ipynb
+++ b/ai-large-circuit-speed-test.ipynb
@@ -12,8 +12,18 @@
     "from qiskit.quantum_info import random_clifford\n",
     "from qiskit.transpiler import PassManager, generate_preset_pass_manager\n",
     "\n",
-    "from qiskit_ibm_transpiler.ai.collection import CollectLinearFunctions, CollectCliffords, CollectPauliNetworks, CollectPermutations\n",
-    "from qiskit_ibm_transpiler.ai.synthesis import AILinearFunctionSynthesis, AIPauliNetworkSynthesis, AICliffordSynthesis, AIPermutationSynthesis"
+    "from qiskit_ibm_transpiler.ai.collection import (\n",
+    "    CollectLinearFunctions,\n",
+    "    CollectCliffords,\n",
+    "    CollectPauliNetworks,\n",
+    "    CollectPermutations,\n",
+    ")\n",
+    "from qiskit_ibm_transpiler.ai.synthesis import (\n",
+    "    AILinearFunctionSynthesis,\n",
+    "    AIPauliNetworkSynthesis,\n",
+    "    AICliffordSynthesis,\n",
+    "    AIPermutationSynthesis,\n",
+    ")"
    ]
   },
   {
@@ -83,7 +93,7 @@
     "print(\n",
     "    f\"Original Linear Fnc circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
     ")\n",
-    "#circuit.draw(fold=-1, scale=0.3, style=\"iqp\")"
+    "# circuit.draw(fold=-1, scale=0.3, style=\"iqp\")"
    ]
   },
   {
@@ -105,6 +115,7 @@
    "outputs": [],
    "source": [
     "import time\n",
+    "\n",
     "start_time = time.time()\n",
     "ai_linear_functions_synthesis_pass = PassManager(\n",
     "    [\n",
@@ -148,12 +159,14 @@
     "print(\n",
     "    f\"Synthesized Linear Fnc circuit (local AI) -> Depth: {synthesized_circuit_local.decompose(reps=3).depth()}, Gates(2q): {synthesized_circuit_local.decompose(reps=3).num_nonlocal_gates()}\"\n",
     ")\n",
-    "complexity = circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    "complexity = (\n",
+    "    circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    ")\n",
     "speed = circuit.decompose(reps=3).num_nonlocal_gates() / delta\n",
     "speed2 = complexity / delta\n",
     "print(f\">>>>Gate Speed: {speed:.2f} gates/second\")\n",
     "print(f\">>>>Complexity Speed: {speed2:.2f} complexity/second\")\n",
-    "#synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
+    "# synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
    ]
   },
   {
@@ -190,7 +203,7 @@
     "    f\"Original Permutations circuit -> Depth: {circuit.decompose(reps=3).depth()}, Gates(2q): {circuit.decompose(reps=3).num_nonlocal_gates()}\"\n",
     ")\n",
     "\n",
-    "#circuit.draw(fold=-1, scale=0.3, style=\"iqp\")"
+    "# circuit.draw(fold=-1, scale=0.3, style=\"iqp\")"
    ]
   },
   {
@@ -200,7 +213,7 @@
    "outputs": [],
    "source": [
     "qiskit_lvl3_transpiler = generate_preset_pass_manager(\n",
-    "optimization_level=3, coupling_map=coupling_map\n",
+    "    optimization_level=3, coupling_map=coupling_map\n",
     ")\n",
     "lvl3_transpiled_circuit = qiskit_lvl3_transpiler.run(circuit)"
    ]
@@ -212,6 +225,7 @@
    "outputs": [],
    "source": [
     "import time\n",
+    "\n",
     "start_time = time.time()\n",
     "ai_linear_functions_synthesis_pass = PassManager(\n",
     "    [\n",
@@ -219,7 +233,7 @@
     "            do_commutative_analysis=commutative,\n",
     "            collect_from_back=backwards,\n",
     "            max_block_size=n_qubits,\n",
-    "        ), ## or max_block_size=27\n",
+    "        ),  ## or max_block_size=27\n",
     "        AIPermutationSynthesis(coupling_map=coupling_map),\n",
     "    ]\n",
     ")\n",
@@ -256,12 +270,14 @@
     "print(\n",
     "    f\"Synthesized Permutations circuit (local AI) -> Depth: {synthesized_circuit_local.decompose(reps=3).depth()}, Gates(2q): {synthesized_circuit_local.decompose(reps=3).num_nonlocal_gates()}\"\n",
     ")\n",
-    "complexity = circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    "complexity = (\n",
+    "    circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    ")\n",
     "speed = circuit.decompose(reps=3).num_nonlocal_gates() / delta\n",
     "speed2 = complexity / delta\n",
     "print(f\">>>>Gate Speed: {speed:.2f} gates/second\")\n",
     "print(f\">>>>Complexity Speed: {speed2:.2f} complexity/second\")\n",
-    "#synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
+    "# synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
    ]
   },
   {
@@ -289,7 +305,7 @@
     "print(\n",
     "    f\"Original EfficientSU2 circuit -> Depth: {circuit.depth()}, Gates(2q): {circuit.num_nonlocal_gates()}\"\n",
     ")\n",
-    "#circuit.draw(fold=-1, scale=0.2, style=\"iqp\")"
+    "# circuit.draw(fold=-1, scale=0.2, style=\"iqp\")"
    ]
   },
   {
@@ -299,7 +315,7 @@
    "outputs": [],
    "source": [
     "qiskit_lvl3_transpiler = generate_preset_pass_manager(\n",
-    "optimization_level=3, coupling_map=coupling_map\n",
+    "    optimization_level=3, coupling_map=coupling_map\n",
     ")\n",
     "lvl3_transpiled_circuit = qiskit_lvl3_transpiler.run(circuit)"
    ]
@@ -311,6 +327,7 @@
    "outputs": [],
    "source": [
     "import time\n",
+    "\n",
     "start_time = time.time()\n",
     "ai_linear_functions_synthesis_pass = PassManager(\n",
     "    [\n",
@@ -354,12 +371,14 @@
     "print(\n",
     "    f\"Synthesized EfficientSU2 circuit (local AI) -> Depth: {synthesized_circuit_local.decompose(reps=3).depth()}, Gates(2q): {synthesized_circuit_local.decompose(reps=3).num_nonlocal_gates()}\"\n",
     ")\n",
-    "complexity = circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    "complexity = (\n",
+    "    circuit.decompose(reps=3).depth() * circuit.decompose(reps=3).num_nonlocal_gates()\n",
+    ")\n",
     "speed = circuit.decompose(reps=3).num_nonlocal_gates() / delta\n",
     "speed2 = complexity / delta\n",
     "print(f\">>>>Gate Speed: {speed:.2f} gates/second\")\n",
     "print(f\">>>>Complexity Speed: {speed2:.2f} complexity/second\")\n",
-    "#synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
+    "# synthesized_circuit_local.draw(fold=-1, scale=0.3, style=\"iqp\")"
    ]
   }
  ],

--- a/ai-large-circuit-speed-test.ipynb
+++ b/ai-large-circuit-speed-test.ipynb
@@ -8,20 +8,20 @@
    "source": [
     "import numpy as np\n",
     "from qiskit import QuantumCircuit\n",
-    "from qiskit.circuit.library import Permutation, EfficientSU2\n",
+    "from qiskit.circuit.library import EfficientSU2, Permutation\n",
     "from qiskit.quantum_info import random_clifford\n",
     "from qiskit.transpiler import PassManager, generate_preset_pass_manager\n",
     "\n",
     "from qiskit_ibm_transpiler.ai.collection import (\n",
-    "    CollectLinearFunctions,\n",
     "    CollectCliffords,\n",
+    "    CollectLinearFunctions,\n",
     "    CollectPauliNetworks,\n",
     "    CollectPermutations,\n",
     ")\n",
     "from qiskit_ibm_transpiler.ai.synthesis import (\n",
+    "    AICliffordSynthesis,\n",
     "    AILinearFunctionSynthesis,\n",
     "    AIPauliNetworkSynthesis,\n",
-    "    AICliffordSynthesis,\n",
     "    AIPermutationSynthesis,\n",
     ")"
    ]

--- a/qiskit_ibm_transpiler/ai/collection.py
+++ b/qiskit_ibm_transpiler/ai/collection.py
@@ -32,10 +32,6 @@ from qiskit.transpiler.passes.optimization.collect_and_collapse import (
 from qiskit.transpiler.passes.utils import control_flow
 from qiskit.dagcircuit.dagdependency import DAGDependency
 from collections import deque, defaultdict
-import rustworkx as rx
-import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 CLIFFORD_MAX_BLOCK_SIZE = 9
 LINEAR_MAX_BLOCK_SIZE = 9
@@ -153,7 +149,7 @@ class GreedyBlockCollector(BlockCollector):
         
         # Precompute adjacency structures for better performance
         self._successors_cache = defaultdict(list)
-        self._predecessors_cache = defaultdict(list)
+        # self._predecessors_cache = defaultdict(list)
         
         if self.is_dag_dependency:
             self._precompute_from_dag_dependency()
@@ -169,10 +165,10 @@ class GreedyBlockCollector(BlockCollector):
         for node_id in node_indices:
             if self._collect_from_back:
                 self._successors_cache[node_id] = self.dag.direct_successors(node_id)
-                self._predecessors_cache[node_id] = self.dag.direct_predecessors(node_id)
+                #self._predecessors_cache[node_id] = self.dag.direct_predecessors(node_id)
             else:
                 self._successors_cache[node_id] = self.dag.direct_predecessors(node_id)
-                self._predecessors_cache[node_id] = self.dag.direct_successors(node_id)
+                #self._predecessors_cache[node_id] = self.dag.direct_successors(node_id)
 
     def _precompute_from_dag_circuit(self):
         """Precompute from regular DAGCircuit using standard methods"""
@@ -186,16 +182,6 @@ class GreedyBlockCollector(BlockCollector):
                 succs = [succ for succ in self.dag.successors(node) if isinstance(succ, DAGOpNode)]
             
             self._successors_cache[node] = succs
-            for succ in succs:
-                self._predecessors_cache[succ].append(node)
-
-    # def _direct_preds(self, node):
-    #     """Returns direct predecessors of a node using precomputed cache."""
-    #     return self._predecessors_cache.get(node, [])
-
-    # def _direct_succs(self, node):
-    #     """Returns direct successors of a node using precomputed cache."""
-    #     return self._successors_cache.get(node, [])
 
     def collect_matching_block(
         self, filter_fn: Callable, max_block_width: Union[int, None] = None

--- a/qiskit_ibm_transpiler/ai/collection.py
+++ b/qiskit_ibm_transpiler/ai/collection.py
@@ -12,6 +12,7 @@
 
 """Replace each sequence of Clifford, Linear Function or Permutation gates by a single block of these types of gate."""
 
+from collections import defaultdict, deque
 from functools import partial
 from typing import Callable, Union
 
@@ -23,6 +24,7 @@ from qiskit.converters import circuit_to_dag, dag_to_dagdependency, dagdependenc
 from qiskit.dagcircuit import DAGDepNode, DAGOpNode
 from qiskit.dagcircuit.collect_blocks import BlockCollector
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
+from qiskit.dagcircuit.dagdependency import DAGDependency
 from qiskit.quantum_info.operators import Clifford
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passes.optimization.collect_and_collapse import (
@@ -30,8 +32,6 @@ from qiskit.transpiler.passes.optimization.collect_and_collapse import (
     collapse_to_operation,
 )
 from qiskit.transpiler.passes.utils import control_flow
-from qiskit.dagcircuit.dagdependency import DAGDependency
-from collections import deque, defaultdict
 
 CLIFFORD_MAX_BLOCK_SIZE = 9
 LINEAR_MAX_BLOCK_SIZE = 9


### PR DESCRIPTION
### Summary
This PR addresses [#173](https://github.com/qiskit-community/qiskit-ai-pass-manager/issues/173) by improving the performance of the collection passes used for identifying N-qubit blocks in circuit optimization. 
#UnitaryHack2025

### Details and comments
The optimizations mainly focus on precomputing node siblings and more efficient queue handling in GreedyBlockCollector and Flatten, resulting in a ~2x speedup in some tested cases. I see some other ways to increase performance even more but this implies changes on other qiskit repos or duplicating functions and classes (like dag_to_dagdependency), I also noticed in the comments that qiskit.dagcircuit.DagDependency needs to be refactored and perhaps is where the major optimization should come from but I wonder if this is out of the scope of this issue.

I don't know the extent of code qiskit is complied in rust but I noticed these repos use rustworkx for efficient dag operations executing and indeed many operations of BlockCollector are already in rust, so perhaps the aim is not to actually rewrite all this in rust but to use more efficiently all dag/node operations to get more benefit of this bridge library.

I included a notebook to test different random circuit sizes to measure the performance.
Other tests were not performed as it seems I require a IBM Qiskit pro account