### PR TITLE
Transpiler function interface

### DIFF
--- a/qiskit_ibm_transpiler/transpiler_service.py
+++ b/qiskit_ibm_transpiler/transpiler_service.py
@@ -32,8 +32,8 @@ from typing import Dict, List, Literal, Union
 from qiskit import QuantumCircuit
 
 from .types import OptimizationOptions
-from .wrappers.transpile import TranspileAPI
 from .wrappers.function_transpile import QiskitTranspilerFunction
+from .wrappers.transpile import TranspileAPI
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class TranspilerService:
         **kwargs,
     ) -> None:
         """Initializes the instance."""
-        if ai == 'false':
+        if ai == "false":
             self.transpiler_service = QiskitTranspilerFunction(**kwargs)
         else:
             self.transpiler_service = TranspileAPI(**kwargs)

--- a/qiskit_ibm_transpiler/transpiler_service.py
+++ b/qiskit_ibm_transpiler/transpiler_service.py
@@ -33,6 +33,7 @@ from qiskit import QuantumCircuit
 
 from .types import OptimizationOptions
 from .wrappers.transpile import TranspileAPI
+from .wrappers.function_transpile import QiskitTranspilerFunction
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +72,10 @@ class TranspilerService:
         **kwargs,
     ) -> None:
         """Initializes the instance."""
-
-        self.transpiler_service = TranspileAPI(**kwargs)
+        if ai == 'false':
+            self.transpiler_service = QiskitTranspilerFunction(**kwargs)
+        else:
+            self.transpiler_service = TranspileAPI(**kwargs)
 
         self.backend_name = backend_name
         self.coupling_map = coupling_map

--- a/qiskit_ibm_transpiler/wrappers/function_transpile.py
+++ b/qiskit_ibm_transpiler/wrappers/function_transpile.py
@@ -17,7 +17,9 @@ from typing import Dict, List, Union
 from qiskit import QuantumCircuit
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit_serverless import ServerlessClient
+
 from qiskit_ibm_transpiler.types import OptimizationOptions
+
 from .base import _get_token_from_system
 
 # TODO: add actual logging if required, else remove this
@@ -26,10 +28,11 @@ logger = logging.getLogger(__name__)
 
 class QiskitTranspilerFunction:
     """A helper class that used the qiskit runtime function interface for transpilation"""
+
     SERVERLESS_URL = "https://qiskit-serverless.quantum.ibm.com"
     DEFAULT_CHANNEL = "ibm_cloud"
     TRANSPILER_FUNCTION_NAME = "ibm/transpiler-function"
-    
+
     def __init__(
         self,
         url: str = None,

--- a/qiskit_ibm_transpiler/wrappers/function_transpile.py
+++ b/qiskit_ibm_transpiler/wrappers/function_transpile.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2025 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Transpilation via the transpiler qiskit function"""
+
+import logging
+from typing import Dict, List, Union
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler.exceptions import TranspilerError
+from qiskit_serverless import ServerlessClient
+from qiskit_ibm_transpiler.types import OptimizationOptions
+from .base import _get_token_from_system
+
+# TODO: add actual logging if required, else remove this
+logger = logging.getLogger(__name__)
+
+
+class QiskitTranspilerFunction:
+    """A helper class that used the qiskit runtime function interface for transpilation"""
+    SERVERLESS_URL = "https://qiskit-serverless.quantum.ibm.com"
+    DEFAULT_CHANNEL = "ibm_cloud"
+    TRANSPILER_FUNCTION_NAME = "ibm/transpiler-function"
+    
+    def __init__(
+        self,
+        url: str = None,
+        token: str = None,
+        channel: str = None,
+        timeout: int = 300,
+        instance: str = None,
+    ):
+        """Connects the serverless client and initialized the function"""
+        if url is None:
+            url = self.SERVERLESS_URL
+        if token is None:
+            token = _get_token_from_system()
+        if channel is None:
+            channel = self.DEFAULT_CHANNEL
+        self.instance = instance
+        self.serverless = ServerlessClient(
+            host=url, channel=channel, token=token, instance=self.instance
+        )
+        self.function = self.serverless.get(self.TRANSPILER_FUNCTION_NAME)
+        self.timeout = timeout
+
+    def transpile(
+        self,
+        circuits: Union[List[QuantumCircuit], QuantumCircuit],
+        optimization_level: int,
+        backend: Union[str, None] = None,
+        coupling_map: Union[List[List[int]], None] = None,
+        optimization_preferences: Union[
+            OptimizationOptions, List[OptimizationOptions], None
+        ] = None,
+        qiskit_transpile_options: Dict = None,
+        use_fractional_gates: bool = False,
+        **kwargs
+    ):
+        """Calls the transpiler function with the given inputs"""
+        # TODO: are optimization_preferences supported in the transpiler function?
+        # should they be merged with qiskit_transpile_options?
+        # if backend is None, get a default one using the serverless client
+        job = self.function.run(
+            circuits=circuits,
+            optimization_level=optimization_level,
+            backend_name=backend,
+            coupling_map=coupling_map,
+            transpile_options=qiskit_transpile_options,
+            use_fractional_gates=use_fractional_gates,
+            instance=self.instance,
+        )
+        # TODO: catch exceptions, fail gracefully
+        job_result = job.result(maxwait=self.timeout)
+        if isinstance(job_result, dict) and "transpiled_circuits" in job_result:
+            transpiled_circuits = job_result["transpiled_circuits"]
+            # TODO: we follow suit with the old service which returns the circuit when there's only one
+            # but should it be the case if `circuits` was a list of length 1 and not a `QuantumCircuit`?
+            return (
+                transpiled_circuits
+                if len(transpiled_circuits) > 1
+                else transpiled_circuits[0]
+            )
+        # TODO: can be more specific; if job_result is a dict but transpilation failed
+        # then job_result['exceptions'] might be informative
+        raise TranspilerError("Transpilation failed")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 qiskit>=1.4.2
 backoff~=2.0
 qiskit_ibm_runtime>=0.37.0
+qiskit-serverless>=0.25.0
 qiskit-qasm3-import~=0.4
 black==24.1.1
 black[jupyter]==24.1.1


### PR DESCRIPTION
### Summary
This PR switches `qiskit-ibm-transpiler` to using the transpiler qiskit function, instead of the now obsolete cloud transpiler.


### Details and comments
* Connection to the qiskit function is done internally, using an instance of `ServerlessClient`. This should be more or less seamless for users, but see below for specific problem yet to be addressed.

* Unlike the cloud transpiler, the qiskit function interface is more straightforward, akin to using the `qiskit` transpiler locally. All the layout-related code previously used does not seem to be relevant here, as circuit encoding and decoding is always done using the layout-preserving `qpy` format.

It is not completely clear how to test the new module as part of the package's testing framework; for e2e testing we'll need to add new token to the secrets (and maybe instance? see below) since the current `ibm_quantum` channel used in `.github/workflows/ci.yml` is obsolete.

### Working example
This example uses the staging API.

```python

from qiskit.circuit.random import random_circuit
from qiskit_ibm_transpiler import TranspilerService
from dotenv import load_dotenv
import os
load_dotenv()

instance = os.environ["QISKIT_INSTANCE"]
token=os.environ["QISKIT_TOKEN"]
url="https://qiskit-serverless-dev.quantum.ibm.com"
channel="ibm_cloud"
qc = random_circuit(5, depth=3, seed=42)
cloud_transpiler_service = TranspilerService(
    backend_name="test_eagle",
    ai='false',
    optimization_level=2,
    instance=instance,
    url=url,
    token=token,
)
transpiled_qc = cloud_transpiler_service.run(qc)
print(f"Before:\n{qc}\nAfter:\n{transpiled_qc}")
```

### Remaining issues
1. Currenty, the transpiler function requires passing the `instance` parameter explicitly. Since it is not yet clear to me how to search for it locally (like in `_get_token_from_system`) is needs to be passed explicitly to `TranspilerService` as well. This is undesired and should be fixed.
2. The `optimization_preferences` parameter that was used with the cloud transpiler seems irrelevant here. The question is whether the data it contains should be merged with the usual `qiskit_transpile_options` parameter.
3. We need to decide whether logging is necessary here - and if so, implement informative logging.
4. Small issue: When returning the transpiled circuits, `TranspileAPI` returns a `QuantumCircuit` if the resulting list is of size 1. It seems to me that it might be better to do so only when the user passed a `QuantumCircuit` object; if the user passed a list, even of size 1, it seems more reasonable that they might expect a list in return (e.g. otherwise they have to write additional code differentiating the case where the list they pass is of size 1 or more).

Issue checklist:

- [ ] Working e2e tests
- [ ] Handle the `instance` parameter
- [ ] Decide what to do with `optimization_preferences` 
- [ ] Logging
- [ ] Better exception handling
- [ ] Decide on the output format when the list is of size 1