### PR TITLE
Enable `local_mode` by default for `AIPauliNetworkSynthesis` and solving a error for non-synthesized circuits

### DIFF
--- a/qiskit_ibm_transpiler/ai/synthesis.py
+++ b/qiskit_ibm_transpiler/ai/synthesis.py
@@ -353,7 +353,7 @@ class AIPauliNetworkSynthesis(AISynthesis):
         backend: Union[Backend, None] = None,
         replace_only_if_better: bool = True,
         max_threads: Union[int, None] = None,
-        local_mode: bool = False,
+        local_mode: bool = True,
         **kwargs,
     ) -> None:
         ai_synthesis_provider = (

--- a/qiskit_ibm_transpiler/wrappers/ai_local_synthesis.py
+++ b/qiskit_ibm_transpiler/wrappers/ai_local_synthesis.py
@@ -22,7 +22,6 @@ from qiskit.circuit.library import LinearFunction
 from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.quantum_info import Clifford
 from qiskit.transpiler import CouplingMap
-from qiskit.transpiler.exceptions import TranspilerError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -334,7 +333,7 @@ def get_synthesized_pauli_circuits(
             )
         except BaseException as e:
             logger.warning(e)
-            raise TranspilerError(f"{e}")
+            continue
 
         input_circuit_dec = circuits[index].decompose(
             ["swap", "rxx", "ryy", "rzz", "rzx", "rzy", "ryx"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR enables `local_mode` by default for `AIPauliNetworkSynthesis` and solving a error for non-synthesized circuits. Fixes #197 

