### PR TITLE
Run ci action when PR is merged to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@
 
 name: CI Pipeline
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run-lint:


### PR DESCRIPTION
### Summary

Since PRs created from forks cannot access to GH actions secrets, we [tried to remove](https://github.com/Qiskit/qiskit-ibm-transpiler/pull/200) all the dependencies that require authentication tokens.
There are still 2 tests that requires those tokens, so [they are skipped ](https://github.com/Qiskit/qiskit-ibm-transpiler/blob/main/.github/workflows/ci.yml#L63)in secrets are not present. When we review PRs created from forks, we are required to check those tests in our local, but as an extra security measure we decided to run ci tests right after PR is merged to main so we are 100% sure that all test pass

### Details and comments
