### PR TITLE
Fix missing uv dependency in upload-docs.yml

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r ./requirements-dev.txt
+      - name: Sync dependencies (dev)
+        run: uv sync --group dev
 
       - name: Build documentation
         uses: ./.github/actions/build-docs


### PR DESCRIPTION
### Summary

Fix `uv: command not found` error in  Upload Documentation.

I'm not sure if we also have to update something in the [cd.yml](https://github.com/Qiskit/qiskit-ibm-transpiler/blob/main/.github/workflows/cd.yml) workflow

### Details and comments
